### PR TITLE
Explicitly require yajl in http_methods.

### DIFF
--- a/lib/remotely/http_methods.rb
+++ b/lib/remotely/http_methods.rb
@@ -1,5 +1,7 @@
 module Remotely
   module HTTPMethods
+    require 'yajl'
+
     # HTTP status codes that are represent successful requests
     SUCCESS_STATUSES = (200..299)
 


### PR DESCRIPTION
I needed to explicitly require Yajl in http_methods.rb to prevent the following:

NameError: uninitialized constant Remotely::HTTPMethods::Yajl

Environment:
Rails 3.2.6
Ruby 1.9.3p194
