### PR TITLE
Jruby compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 1.9.3
   - 1.9.2
+  - jruby-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,12 @@
 source :rubygems
 gemspec
+
+group :development, :test do
+  platforms :mri do
+    gem "debugger"
+  end
+
+  platforms :jruby do
+    gem "ruby-debug"
+  end
+end

--- a/lib/remotely.rb
+++ b/lib/remotely.rb
@@ -4,7 +4,7 @@ require "active_support/inflector"
 require "active_support/concern"
 require "active_support/core_ext/hash"
 require "active_model"
-require "yajl"
+require "multi_json"
 
 require "remotely/ext/url"
 require "remotely/application"

--- a/lib/remotely/http_methods.rb
+++ b/lib/remotely/http_methods.rb
@@ -82,7 +82,7 @@ module Remotely
       path   = expand(path)
       klass  = options.delete(:class)
       parent = options.delete(:parent)
-      body   = options.delete(:body) || Yajl::Encoder.encode(options)
+      body   = options.delete(:body) || MultiJson.dump(options)
 
       before_request(path, :post, body)
       raise_if_html(app.connection.post(path, body))
@@ -98,7 +98,7 @@ module Remotely
     #
     def put(path, options={})
       path = expand(path)
-      body = options.delete(:body) || Yajl::Encoder.encode(options)
+      body = options.delete(:body) || MultiJson.dump(options)
 
       before_request(path, :put, body)
       raise_if_html(app.connection.put(path, body))
@@ -173,7 +173,7 @@ module Remotely
     def parse_response(response, klass=nil, parent=nil)
       return false if response.status >= 400
 
-      body  = Yajl::Parser.parse(response.body) rescue nil
+      body  = MultiJson.load(response.body) rescue nil
       klass = (klass || self)
 
       case body

--- a/lib/remotely/model.rb
+++ b/lib/remotely/model.rb
@@ -209,7 +209,7 @@ module Remotely
       url    = new_record? ? uri        : URL(uri, id)
 
       resp = public_send(method, url, attrs)
-      body = Yajl::Parser.parse(resp.body)
+      body = MultiJson.load(resp.body)
 
       if resp.status == status && !body.nil?
         self.attributes.merge!(body.symbolize_keys)
@@ -268,7 +268,7 @@ module Remotely
     end
 
     def to_json
-      Yajl::Encoder.encode(self.attributes)
+      MultiJson.dump(self.attributes)
     end
 
   private

--- a/remotely.gemspec
+++ b/remotely.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport"
   gem.add_dependency "activemodel"
   gem.add_dependency "faraday"
-  gem.add_dependency "yajl-ruby"
+  gem.add_dependency "multi_json"
 end

--- a/spec/remotely/model_spec.rb
+++ b/spec/remotely/model_spec.rb
@@ -74,14 +74,14 @@ describe Remotely::Model do
     end
 
     it "returns an instance with errors when the creation fails" do
-      body = Yajl.dump({errors: {base: ["error"]}})
+      body = MultiJson.dump({errors: {base: ["error"]}})
       stub_request(:post, %r[/adventures]).to_return(status: 500, body: body)
       Adventure.create(attrs).errors[:base].should include("error")
     end
   end
 
   describe ".find_or_" do
-    let(:body)         { Yajl::Encoder.encode([{id: 1, name: "BubbleGum"}]) }
+    let(:body)         { MultiJson.dump([{id: 1, name: "BubbleGum"}]) }
     let(:stub_success) { stub_request(:get, "#{app}/adventures/search?name=BubbleGum").to_return(body: body) }
     let(:stub_failure) { stub_request(:get, "#{app}/adventures/search?name=BubbleGum").to_return(body: "[]") }
 
@@ -176,7 +176,7 @@ describe Remotely::Model do
       end
 
       it "sets errors on a failure" do
-        body = Yajl.dump({errors: {base: ["error"]}})
+        body = MultiJson.dump({errors: {base: ["error"]}})
         stub_request(:post, %r(/adventures)).to_return(status: 409, body: body)
         adventure.save
         adventure.errors.should_not be_empty
@@ -216,7 +216,7 @@ describe Remotely::Model do
     end
 
     it "sets errors on failure" do
-      body = Yajl.dump({errors: {base: ["error"]}})
+      body = MultiJson.dump({errors: {base: ["error"]}})
       stub_request(:put, %r[/adventures/1]).to_return(status: 500, body: body)
       subject.update_attributes(updates)
       subject.errors[:base].should include("error")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require "support/test_classes"
 RSpec.configure do |c|
   c.before do
     WebmockHelpers.stub!
+    Remotely.reset!
+    Remotely.configure { app :adventure_app, "http://localhost:1234" }
   end
 
   def to_json(obj)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "remotely"
 require 'webmock/rspec'
-require "yajl"
 WebMock.disable_net_connect!
 require "support/webmock"
 require "support/test_classes"
@@ -11,6 +10,6 @@ RSpec.configure do |c|
   end
 
   def to_json(obj)
-    Yajl::Encoder.encode(obj)
+    MultiJson.dump(obj)
   end
 end

--- a/spec/support/test_classes.rb
+++ b/spec/support/test_classes.rb
@@ -1,9 +1,5 @@
 require "ostruct"
 
-Remotely.configure do
-  app :adventure_app, "http://localhost:1234"
-end
-
 class BaseTestClass < OpenStruct
   extend  ActiveModel::Naming
   include Remotely::Associations

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -31,8 +31,8 @@ module WebmockHelpers
   end
 
   def stub(method, url, response={})
-    unless response.is_a?(Proc)
-      response[:body]    = Yajl::Encoder.encode(response[:body])
+    unless response.is_a?(Proc) || response[:body].is_a?(Proc)
+      response[:body]    = MultiJson.dump(response[:body])
       response[:headers] = { "Content-Type" => "application/json" }
     end
     stub_request(method, url).to_return(response)


### PR DESCRIPTION
Yajl is a C extension, which won't work for non-MRI environments, obviously. MultiJson will either use the JSON library already loaded in the application (Yajl in our case) or fallback to a pure Ruby one. That should work for most environments.
