### PR TITLE
Header options are now passed along for put/post

### DIFF
--- a/lib/remotely/http_methods.rb
+++ b/lib/remotely/http_methods.rb
@@ -79,13 +79,15 @@ module Remotely
     #   parsed response body.
     #
     def post(path, options={})
-      path   = expand(path)
-      klass  = options.delete(:class)
-      parent = options.delete(:parent)
-      body   = options.delete(:body) || MultiJson.dump(options)
+      path      = expand(path)
+      klass     = options.delete(:class)
+      parent    = options.delete(:parent)
+      body      = options.delete(:body) || MultiJson.dump(options)
+      headers   = options.delete(:headers) || {}
+      headers['Content-Type'] ||= 'application/json'
 
       before_request(path, :post, body)
-      raise_if_html(app.connection.post(path, body))
+      raise_if_html(app.connection.post(path, body, headers))
     end
 
     # PUT request.
@@ -99,9 +101,11 @@ module Remotely
     def put(path, options={})
       path = expand(path)
       body = options.delete(:body) || MultiJson.dump(options)
+      headers   = options.delete(:headers) || {}
+      headers['Content-Type'] ||= 'application/json'
 
       before_request(path, :put, body)
-      raise_if_html(app.connection.put(path, body))
+      raise_if_html(app.connection.put(path, body, headers))
     end
 
     # DELETE request.
@@ -137,7 +141,7 @@ module Remotely
     #
     def before_request(uri, http_verb = :get, options = {})
       if ENV['REMOTELY_DEBUG']
-        puts "-> #{http_verb.to_s.upcase} #{uri}" 
+        puts "-> #{http_verb.to_s.upcase} #{uri}"
         puts "   #{options.inspect}"
       end
     end

--- a/spec/remotely/http_methods_spec.rb
+++ b/spec/remotely/http_methods_spec.rb
@@ -22,4 +22,37 @@ describe Remotely::HTTPMethods do
     stub_request(:delete, %r(/things)).to_return(body: "<html><head><title></title></head></html>")
     expect { http_delete("/things") }.to raise_error(Remotely::NonJsonResponseError)
   end
+
+  it "passes the correct headers for post requests" do
+    stub_request(:post, %r(/things)).
+      to_return(body: "{\"key\":\"value\"}")
+
+    post("/things", headers: {'Content-Type'=>'text/plain'})
+
+    a_request(:post, %r(/things)).
+      with(headers: {'Content-Type'=>'text/plain'}).
+      should have_been_made
+  end
+
+  it "defaults the Content-Type header to be application/json" do
+    stub_request(:post, %r(/things)).
+      to_return(body: "{\"key\":\"value\"}")
+
+    post("/things")
+
+    a_request(:post, %r(/things)).
+      with(headers: {'Content-Type'=>'application/json'}).
+      should have_been_made
+  end
+
+  it "passes the correct headers for put requests" do
+    stub_request(:put, %r(/things)).
+      to_return(body: "{\"key\":\"value\"}")
+
+    put("/things", headers: {'Content-Type'=>'application/pdf'})
+
+    a_request(:put, %r(/things)).
+      with(headers: {'Content-Type'=>'application/pdf'}).
+      should have_been_made
+  end
 end


### PR DESCRIPTION
This allows the client to set the request headers for put/post requests.
Fix for ttps://www.pivotaltracker.com/projects/459563#
