### PR TITLE
Add additional passthrough authorization options and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,59 @@ A path can include "`:id`" anywhere in it, which is replaced by the instance's `
     m.id   # => 1
     m.legs # => Requests "/millepieds/1/legs"
 
+## Authorization
+
+Remotely is setup to allow basic auth, token auth, or custom authentication schemes. 
+
+**Basic Auth**
+
+`basic_auth` accepts 2 String params: `username` and `password`
+	
+    # 'Authorization' header => "Basic dXNlcjpwYXNzd29yZA=="
+    
+    Remotely.configure do
+      app :legsapp do
+        url "http://somanylegs.com/api/v1"
+        basic_auth "username", "password"
+      end
+    end
+    
+**Token Auth**
+
+`token_auth` accepts a String param for the `token`, and an optional Hash of token options
+	
+    # 'Authorization' header => "Token token=\"abcdef\", foo=\"bar\""
+    
+    Remotely.configure do
+      app :legsapp do
+        url "http://somanylegs.com/api/v1"
+        token_auth "abcdef", {:foo => 'bar'}
+      end
+    end
+    
+**Custom Authorization**
+
+`authorization` accepts a String param for the `type`, and either a String or Hash `token`. A String value is taken literally, and a Hash is encoded into comma separated key/value pairs.
+	
+    # 'Authorization' header => "Bearer mF_9.B5f-4.1JqM"
+    
+    Remotely.configure do
+      app :legsapp do
+        url "http://somanylegs.com/api/v1"
+        authorization 'Bearer', 'mF_9.B5f-4.1JqM'
+      end
+    end
+&nbsp;
+
+    # 'Authorization' header => "OAuth token=\"abcdef\", foo=\"bar\""
+    
+    Remotely.configure do
+      app :legsapp do
+        url "http://somanylegs.com/api/v1"
+        authorization 'OAuth', {:token => 'abcdef', :foo => 'bar'}
+      end
+    end
+
 ## Fetched Objects
 
 Remote associations are Remotely::Model objects. Whatever data the API returns, becomes the attributes of the Model.

--- a/lib/remotely/application.rb
+++ b/lib/remotely/application.rb
@@ -25,6 +25,28 @@ module Remotely
       return @basic_auth unless user && password
       @basic_auth = [user, password]
     end
+    
+    # Set or get the Authorization header.
+    #  - As seen here: https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb#L204
+    # 
+    # @param [String] token   - The String token.
+    # @param [Hash]   options - Optional Hash of extra token options.
+    #
+    def token_auth(token=nil, options={})
+      return @token_auth unless token
+      @token_auth = [token, options]
+    end
+    
+    # Set or get a custom Authorization header.
+    #  - As seen here: https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb#L227
+    # 
+    # @param [String]       type    - The String authorization type.
+    # @param [String|Hash]  token   - The String or Hash token.  A String value is taken literally, and a Hash is encoded into comma separated key/value pairs.
+    #
+    def authorization(type=nil, token=nil)
+      return @authorization unless type && token
+      @authorization = [type, token]
+    end
 
     # Connection to the application (with BasicAuth if it was set).
     #
@@ -35,8 +57,10 @@ module Remotely
         b.request :url_encoded
         b.adapter :net_http
       end
-
-      @connection.basic_auth(*@basic_auth) if @basic_auth
+      
+      @connection.basic_auth(*@basic_auth)        if @basic_auth
+      @connection.token_auth(*@token_auth)        if @token_auth
+      @connection.authorization(*@authorization)  if @authorization
       @connection
     end
 

--- a/spec/remotely/application_spec.rb
+++ b/spec/remotely/application_spec.rb
@@ -15,6 +15,21 @@ describe Remotely::Application do
     app = Remotely::Application.new(:name) { basic_auth "user", "pass" }
     app.basic_auth.should == ["user", "pass"]
   end
+  
+  it "sets token auth credentials" do
+    app = Remotely::Application.new(:name) { token_auth "token", {:foo => :bar} }
+    app.token_auth.should == ["token", {:foo => :bar}]
+  end
+  
+  it "sets custom authorization credentials as a string" do
+    app = Remotely::Application.new(:name) { authorization "OAuth", "token=foo" }
+    app.authorization.should == ["OAuth", "token=foo"]
+  end
+  
+  it "sets custom authorization credentials as a hash" do
+    app = Remotely::Application.new(:name) { authorization "OAuth", {:token => :foo} }
+    app.authorization.should == ["OAuth", {:token => :foo}]
+  end
 
   it "has a connection to the app" do
     app = Remotely::Application.new(:name) { url "http://example.com" }
@@ -25,6 +40,22 @@ describe Remotely::Application do
     app = Remotely::Application.new(:name) do
       url        "http://example.com"
       basic_auth "user", "pass"
+    end
+    app.connection.headers["authorization"].should_not be_nil
+  end
+  
+  it "has a connection with token auth to the app" do
+    app = Remotely::Application.new(:name) do
+      url        "http://example.com"
+      token_auth "token", {:foo => :bar}
+    end
+    app.connection.headers["authorization"].should_not be_nil
+  end
+  
+  it "has a connection with custom authorization to the app" do
+    app = Remotely::Application.new(:name) do
+      url           "http://example.com"
+      authorization "OAuth", {:token => :foo}
     end
     app.connection.headers["authorization"].should_not be_nil
   end

--- a/spec/remotely/model_spec.rb
+++ b/spec/remotely/model_spec.rb
@@ -279,6 +279,81 @@ describe Remotely::Model do
       a_request(:get, "#{app}/adventures/1").with(headers: {})
     end
   end
+  
+  context "token auth" do
+    before do
+      Remotely.configure do
+        app :adventure_app do
+          url "http://localhost:3000"
+          token_auth "token", {:foo => :bar}
+        end
+      end
+    end
+
+    after do
+      Remotely.reset!
+    end
+
+    it "sends Authorization headers when token auth is configured" do
+      Adventure.find(1)
+      a_request(:get, "#{app}/adventures/1").with(headers: {'Authorization' => "Token token=token foo=bar"})
+    end
+
+    it "doesn't send Authorization headers when token auth is not configured" do
+      Adventure.find(1)
+      a_request(:get, "#{app}/adventures/1").with(headers: {})
+    end
+  end
+  
+  context "custom authorization as a string" do
+    before do
+      Remotely.configure do
+        app :adventure_app do
+          url "http://localhost:3000"
+          authorization "OAuth", "token=foo"
+        end
+      end
+    end
+
+    after do
+      Remotely.reset!
+    end
+
+    it "sends Authorization headers when custom authorization is configured" do
+      Adventure.find(1)
+      a_request(:get, "#{app}/adventures/1").with(headers: {'Authorization' => "OAuth token=foo"})
+    end
+
+    it "doesn't send Authorization headers when custom authorization is not configured" do
+      Adventure.find(1)
+      a_request(:get, "#{app}/adventures/1").with(headers: {})
+    end
+  end
+  
+  context "custom authorization as a hash" do
+    before do
+      Remotely.configure do
+        app :adventure_app do
+          url "http://localhost:3000"
+          authorization "OAuth", {:token => :foo}
+        end
+      end
+    end
+
+    after do
+      Remotely.reset!
+    end
+
+    it "sends Authorization headers when custom authorization is configured" do
+      Adventure.find(1)
+      a_request(:get, "#{app}/adventures/1").with(headers: {'Authorization' => "OAuth token=foo"})
+    end
+
+    it "doesn't send Authorization headers when custom authorization is not configured" do
+      Adventure.find(1)
+      a_request(:get, "#{app}/adventures/1").with(headers: {})
+    end
+  end
 
   it "sets the app it belongs to" do
     Adventure.app.name.should == :adventure_app

--- a/spec/remotely_spec.rb
+++ b/spec/remotely_spec.rb
@@ -25,4 +25,19 @@ describe Remotely do
     Remotely.configure { app(:appname) { basic_auth "user", "pass" }}
     Remotely.apps[:appname].basic_auth.should == ["user", "pass"]
   end
+  
+  it "saves the token auth credentials" do
+    Remotely.configure { app(:appname) { token_auth "token", {:foo => :bar} }}
+    Remotely.apps[:appname].token_auth.should == ["token", {:foo => :bar}]
+  end
+  
+  it "saves the authorization credentials as a string" do
+    Remotely.configure { app(:appname) { authorization "OAuth", "token=foo" }}
+    Remotely.apps[:appname].authorization.should == [ "OAuth", "token=foo" ]
+  end
+  
+  it "saves the authorization credentials as a hash" do
+    Remotely.configure { app(:appname) { authorization "OAuth", {:token => :foo} }}
+    Remotely.apps[:appname].authorization.should == [ "OAuth", {:token => :foo}]
+  end
 end


### PR DESCRIPTION
As eluded to in #8, I added additional authorization helpers to pass through to the `faraday` gem. I added `token_auth` and `authorization`, which correlate directly to the methods [as found in faraday](https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb).

I added tests for these methods in similar style as the existing tests, which all pass.

Including more than one type of authentication option is not supported for obvious reasons, but if more than 1 is specified, `authorization` takes priority, then `token_auth`, then `basic_auth` due to the nature of the ordering of the `if` statements in the code.
