### PR TITLE
improve HTML tag detection regular expression

### DIFF
--- a/lib/remotely/http_methods.rb
+++ b/lib/remotely/http_methods.rb
@@ -147,7 +147,7 @@ module Remotely
     end
 
     def raise_if_html(response)
-      if response.body =~ %r(<html>)
+      if response.body =~ %r(<html.?*>)i
         raise Remotely::NonJsonResponseError.new(response.body)
       end
       response

--- a/spec/remotely/http_methods_spec.rb
+++ b/spec/remotely/http_methods_spec.rb
@@ -4,12 +4,12 @@ describe Remotely::HTTPMethods do
   include Remotely::HTTPMethods
 
   it "raises NonJsonResponseError when HTML is returned on GET" do
-    stub_request(:get, %r(/things)).to_return(body: "<html><head><title></title></head></html>")
+    stub_request(:get, %r(/things)).to_return(body: "<html lang='en'><head><title></title></head></html>")
     expect { get("/things") }.to raise_error(Remotely::NonJsonResponseError)
   end
 
   it "raises NonJsonResponseError when HTML is returned on POST" do
-    stub_request(:post, %r(/things)).to_return(body: "<html><head><title></title></head></html>")
+    stub_request(:post, %r(/things)).to_return(body: "<HTML><HEAD><TITLE></TITLE></HEAD></HTML>")
     expect { post("/things") }.to raise_error(Remotely::NonJsonResponseError)
   end
 


### PR DESCRIPTION
Previous regular expression failed to match when response body had
uppercase <HTML> tag or if the tag had attributes.
