### PR TITLE
Allow saveable attributes to be referenced on a new object.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ platforms :jruby do
 end
 
 group :development, :test do
-  platforms :mri do
+  platforms :ruby_19 do
     gem "debugger"
   end
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@ be fetched from a remote API instead of the database.
 
 ## Configuration
 
-Apps are where Remotely goes to find association resources. You can define as many as you want, but if you define only one, you can omit the `:app` option from your associations.
+Apps are where Remotely goes to find association resources. You can define as many as you want, but if you define only one, you can omit the `:app` option from your associations. Remotely also supports any Faraday middleware, to configure just call `use_middleware` with the class name and options.
 
     Remotely.configure do
       app :legsapp do
         url "http://somanylegs.com/api/v1"
         basic_auth "username", "password"
+        use_middleware Faraday::HttpCache, store: MyCache.new
       end
+    end
+
+    class Millepied < Remotely::Model
+      app :legsapp
+      uri "/legs"
+
+      # Optional - restrict saveable attributes
+      attr_savable :name, :type
     end
 
 ## Defining Associations

--- a/lib/remotely/model.rb
+++ b/lib/remotely/model.rb
@@ -205,7 +205,7 @@ module Remotely
     def save
       method = new_record? ? :post      : :put
       status = new_record? ? 201        : 200
-      attrs  = new_record? ? attributes : attributes.slice(*savable_attributes)
+      attrs  = new_record? ? attributes : attributes.slice(*savable_attributes << :id)
       url    = new_record? ? uri        : URL(uri, id)
 
       resp = public_send(method, url, attrs)
@@ -221,7 +221,7 @@ module Remotely
     end
 
     def savable_attributes
-      (self.class.savable_attributes || attributes.keys) << :id
+      self.class.savable_attributes || attributes.keys
     end
 
     # Sets multiple errors with a hash
@@ -296,7 +296,7 @@ module Remotely
     end
 
     def method_missing(name, *args, &block)
-      if self.attributes.include?(name)
+      if self.attributes.include?(name) || self.savable_attributes.include?(name)
         self.attributes[name]
       elsif name =~ /(.*)=$/ && self.attributes.include?($1.to_sym)
         self.attributes[$1.to_sym] = args.first

--- a/remotely.gemspec
+++ b/remotely.gemspec
@@ -17,11 +17,10 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 2.6.0"
-  gem.add_development_dependency "webmock"
+  gem.add_development_dependency "webmock", '~> 1.18.0'
 
   gem.add_dependency "activesupport"
   gem.add_dependency "activemodel"
-  gem.add_dependency "http", ">= 0.6.0"
   gem.add_dependency "faraday"
   gem.add_dependency "multi_json"
 end

--- a/remotely.gemspec
+++ b/remotely.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "activesupport"
   gem.add_dependency "activemodel"
+  gem.add_dependency "http", ">= 0.6.0"
   gem.add_dependency "faraday"
   gem.add_dependency "multi_json"
 end

--- a/spec/remotely/model_spec.rb
+++ b/spec/remotely/model_spec.rb
@@ -12,6 +12,10 @@ describe Remotely::Model do
 
     subject { Adventure.new(attrs) }
 
+    it 'should respond to uninitialized attributes defined as saveable' do
+      Adventure.new.name.should == nil
+    end
+
     it "stores which attributes are savable" do
       Adventure.savable_attributes.should == [:name, :type]
     end


### PR DESCRIPTION
Allows use in forms, otherwise you need to initialize with a set of attributes.
Also we shouldn’t append :id each time we call `savable_attributes`