### PR TITLE
Rails 4.2 Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 platforms :jruby do

--- a/lib/remotely.rb
+++ b/lib/remotely.rb
@@ -37,6 +37,10 @@ module Remotely
     def initialize(body)
       @body = body
     end
+
+    def message
+      "#{MESSAGE}: #{@body}"
+    end
   end
 
   class << self

--- a/lib/remotely/http_methods.rb
+++ b/lib/remotely/http_methods.rb
@@ -147,7 +147,7 @@ module Remotely
     end
 
     def raise_if_html(response)
-      if response.body =~ %r(<html>)
+      if response.body =~ %r(<html.?*>)i
         raise Remotely::NonJsonResponseError.new(response.body)
       end
       response

--- a/lib/remotely/http_methods.rb
+++ b/lib/remotely/http_methods.rb
@@ -147,7 +147,7 @@ module Remotely
     end
 
     def raise_if_html(response)
-      if response.body =~ %r(<html.?*>)i
+      if response.body =~ %r(<html.*?>)i
         raise Remotely::NonJsonResponseError.new(response.body)
       end
       response

--- a/lib/remotely/model.rb
+++ b/lib/remotely/model.rb
@@ -1,6 +1,5 @@
 module Remotely
   class Model
-    extend  Forwardable
     extend  ActiveModel::Naming
     include ActiveModel::Conversion
     include Associations
@@ -148,7 +147,7 @@ module Remotely
       end
     end
 
-    def_delegators :"self.class", :uri, :get, :post, :put, :parse_response
+    delegate :uri, :get, :post, :put, :parse_response, to: :"self.class"
 
     # @return [Hash] Key-value of attributes and values.
     attr_accessor :attributes

--- a/lib/remotely/version.rb
+++ b/lib/remotely/version.rb
@@ -1,3 +1,3 @@
 module Remotely
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/remotely/version.rb
+++ b/lib/remotely/version.rb
@@ -1,3 +1,3 @@
 module Remotely
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/lib/remotely/version.rb
+++ b/lib/remotely/version.rb
@@ -1,3 +1,3 @@
 module Remotely
-  VERSION = "0.2.3.pre1"
+  VERSION = "0.2.3.pre2"
 end

--- a/lib/remotely/version.rb
+++ b/lib/remotely/version.rb
@@ -1,3 +1,3 @@
 module Remotely
-  VERSION = "0.2.3.caring1"
+  VERSION = "0.2.3.caring2"
 end

--- a/lib/remotely/version.rb
+++ b/lib/remotely/version.rb
@@ -1,3 +1,3 @@
 module Remotely
-  VERSION = "0.2.2"
+  VERSION = "0.2.3.pre1"
 end

--- a/spec/remotely/http_methods_spec.rb
+++ b/spec/remotely/http_methods_spec.rb
@@ -4,12 +4,12 @@ describe Remotely::HTTPMethods do
   include Remotely::HTTPMethods
 
   it "raises NonJsonResponseError when HTML is returned on GET" do
-    stub_request(:get, %r(/things)).to_return(body: "<html><head><title></title></head></html>")
+    stub_request(:get, %r(/things)).to_return(body: "<html lang='en'><head><title></title></head></html>")
     expect { get("/things") }.to raise_error(Remotely::NonJsonResponseError)
   end
 
   it "raises NonJsonResponseError when HTML is returned on POST" do
-    stub_request(:post, %r(/things)).to_return(body: "<html><head><title></title></head></html>")
+    stub_request(:post, %r(/things)).to_return(body: "<HTML><HEAD><TITLE></TITLE></HEAD></HTML>")
     expect { post("/things") }.to raise_error(Remotely::NonJsonResponseError)
   end
 

--- a/spec/remotely/non_json_response_error_spec.rb
+++ b/spec/remotely/non_json_response_error_spec.rb
@@ -4,6 +4,6 @@ describe Remotely::NonJsonResponseError do
   let(:exception) { Remotely::NonJsonResponseError.new("<html lang='en'><head><title>Not JSON</title></head></html>") }
 
   it "should include the HTML response in the exception message" do
-    expect(exception.message).to match(/<title>Not JSON<\/title>/)
+    exception.message.should match(/<title>Not JSON<\/title>/)
   end
 end

--- a/spec/remotely/non_json_response_error_spec.rb
+++ b/spec/remotely/non_json_response_error_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+
+describe Remotely::NonJsonResponseError do
+  let(:exception) { Remotely::NonJsonResponseError.new("<html lang='en'><head><title>Not JSON</title></head></html>") }
+
+  it "should include the HTML response in the exception message" do
+    expect(exception.message).to match(/<title>Not JSON<\/title>/)
+  end
+end


### PR DESCRIPTION
In Rails 4.2 `Forwardable` and `ActiveModel::Naming` don't play well. Since remotely already depends on `ActiveSupport` and it provides `Module.delegate` we can remove `Forwardable` from `Remotely::Model` and support Rails 4.2.